### PR TITLE
Feat: ✨ Add hook to customize Initiative deck preset

### DIFF
--- a/src/utils/client-hooks.js
+++ b/src/utils/client-hooks.js
@@ -1,6 +1,27 @@
 import { MODULE_NAME, CARD_STACK } from '@module/constants';
 
 /**
+ * A static class (cannot be instantiated) with utility methods
+ * to customize
+ * @static
+ */
+export class YearZeroCombatHook {
+  constructor() {
+    throw new SyntaxError('This class cannot be instantiated!');
+  }
+
+  /**
+   * Changes the default starting Initiative Deck data.
+   * @param {string} src Path to the Initiative Deck preset JSON
+   * @static
+   */
+  static setSourceForInitiativeDeckPreset(src = '') {
+    if (typeof src !== 'string') throw new Error('Source path to the Initiative Deck preset JSON must be a String');
+    CONFIG.Cards.presets.initiative.src = src;
+  }
+}
+
+/**
  * Gets the canvas (if ready).
  * @returns {Canvas}
  */

--- a/src/yze-combat.js
+++ b/src/yze-combat.js
@@ -18,6 +18,7 @@ import { MODULE_NAME } from '@module/constants';
 import { initializeHandlebars } from '@module/handlebars';
 import { registerSystemSettings } from '@module/settings';
 import { setupModule } from '@module/setup';
+import { YearZeroCombatHook } from '@utils/client-hooks';
 import YearZeroCards from './combat/cards';
 import YearZeroCombat from './combat/combat';
 import YearZeroCombatant from './combat/combatant';
@@ -29,9 +30,6 @@ import YearZeroCombatTracker from './sidebar/combat-tracker';
 
 Hooks.once('init', () => {
   logger.log('YZEC | Initializing the Year Zero Combat Module');
-
-  // TODO Hooks.call('yzeCombatInit');
-  // TODO Hooks.call('yzeCombatReady');
 
   // Records configuration values.
   CONFIG.YZE_COMBAT = YZEC;
@@ -47,6 +45,8 @@ Hooks.once('init', () => {
   };
   CONFIG.ui.combat = YearZeroCombatTracker;
 
+  Hooks.call('yzeCombatInit', YearZeroCombatHook);
+
   // registerSheets();
   initializeHandlebars();
   registerSystemSettings();
@@ -60,6 +60,9 @@ Hooks.once('ready', async () => {
   if (game.user.isGM) {
     await setupModule();
   }
+
+  // TODO Hooks.call('yzeCombatReady');
+
   console.log('YZEC | READY!');
 });
 


### PR DESCRIPTION
This PR is a draft concept to add Hooks to configure the default Initiative Deck **before** it is created.

In the module's `Hooks.once('init')`, I have added the following call:
https://github.com/fvtt-fria-ligan/yearzero-combat-fvtt/blob/e45259e0ec445978fea4ce55bb20452b162abb9c/src/yze-combat.js#L48

Which expose a class with the following static function:
https://github.com/fvtt-fria-ligan/yearzero-combat-fvtt/blob/e45259e0ec445978fea4ce55bb20452b162abb9c/src/utils/client-hooks.js#L18-L22

So basically, any Game System can force the module to use their own JSON with the following in its main script:
```js
Hooks.on('yzeCombatInit', foo => foo.setSourceForInitiativeDeckPreset('path/to/my/initiative/deck.json'));
```

Not sure if it is the best way to do that, but it works!

Thoughts?