### PR TITLE
Feat: Add functionality for resetting initiative each round

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Combat initiative order is ascending (lowest first)
 - Initiative groups are supported *(1 card for multiple combatants, create groups with right-click or drag'n-drop)*
 - Combatant cloning is supported *(one token can have multiple initiative entries in a combat instance, useful for monsters with Speed > 1)*
+- Redrawing initiative at the start of each round is supported
 - Swap initiative cards between two combatants
 - Buttons for Fast and Slow actions
 - Combatant configuration *(how many cards to draw, keep best or worst, etc.)*

--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -3,52 +3,51 @@ COMBAT.InitiativeRoll: Draw Initiative
 COMBAT.RollAll: Draw All
 COMBAT.RollNPC: Draw NPCs
 COMBAT.RollsInitiative: '{name} draws an initiative card!'
-SETTINGS.ActorSpeedAttribute: Actor's Speed Attribute
-SETTINGS.ActorSpeedAttributeHint: >-
-  The property key in the actor's data to the attribute that defines how many
-  initiative cards are kept (speed) by the combatant (e.g. system.speed.value).
 SETTINGS.ActorDrawSizeAttribute: Actor's Draw Size Attribute
 SETTINGS.ActorDrawSizeAttributeHint: >-
   The property key in the actor's data to the attribute that defines how many
   initiative cards are drawn by the combatant (e.g. system.reflexes.value).
+SETTINGS.ActorSpeedAttribute: Actor's Speed Attribute
+SETTINGS.ActorSpeedAttributeHint: >-
+  The property key in the actor's data to the attribute that defines how many
+  initiative cards are kept (speed) by the combatant (e.g. system.speed.value).
 SETTINGS.AutoDraw: Automatic Initiative Draw
 SETTINGS.AutoDrawHint: Whether to automatically draw initiative cards.
-SETTINGS.SlowAndFastActions: Enable Slow & Fast Actions
-SETTINGS.SlowAndFastActionsHint: >-
-  Whether to show additional buttons for Slow & Fast Actions in the Combat
-  Tracker.
-SETTINGS.InitiativeDeck: Initiative Deck ID
-SETTINGS.InitiativeDeckHint: ID or name of the Initiative deck from which to draw initiative cards.
 SETTINGS.DiscardPile: Discard Pile ID
 SETTINGS.DiscardPileHint: ID or name of the Discard pile where to put the drawn initiative cards.
 SETTINGS.DuplicateCombatantsOnCombatStart: Duplicate Combatants
-SETTINGS.DuplicateCombatantsOnCombatStartHint: Whether to automatically duplicate combatants who have extra speed on combat start.
+SETTINGS.DuplicateCombatantsOnCombatStartHint: >-
+  Whether to automatically duplicate combatants who have extra speed on combat
+  start.
+SETTINGS.InitiativeDeck: Initiative Deck ID
+SETTINGS.InitiativeDeckHint: ID or name of the Initiative deck from which to draw initiative cards.
 SETTINGS.InitiativeMessaging: Send Initiative Messages
 SETTINGS.InitiativeMessagingHint: Whether to display a chat message when an initiative card is drawn.
 SETTINGS.InitiativeResetDeckOnCombatStart: Reset the Initiative Deck
 SETTINGS.InitiativeResetDeckOnCombatStartHint: >-
   Whether to recall and shuffle all the initiative cards when starting a new
   combat.
+SETTINGS.InitiativeResetEachRound: Reset the Initiative each round
+SETTINGS.InitiativeResetEachRoundHint: >-
+  Whether to reset Initiative at the start of each round. If "Automatic
+  Initiative Draw" is enabled, new Initiative will be drawn each round. If
+  "Reset the Initiative Deck" is enabled the initiative deck will reset at the
+  start of each round as well.
 SETTINGS.InitiativeSortOrder: Initiative Sort Order
-SETTINGS.InitiativeSortOrderHint: Default sort order for initiative.
 SETTINGS.InitiativeSortOrderAscending: Ascending (Lowest first)
 SETTINGS.InitiativeSortOrderDescending: Descending (Highest first)
+SETTINGS.InitiativeSortOrderHint: Default sort order for initiative.
 SETTINGS.MaxDrawSize: Maximum Draw Size
 SETTINGS.MaxDrawSizeHint: Maximum number of cards that can be drawn at once by a single combatant.
+SETTINGS.SlowAndFastActions: Enable Slow & Fast Actions
+SETTINGS.SlowAndFastActionsHint: >-
+  Whether to show additional buttons for Slow & Fast Actions in the Combat
+  Tracker.
 YZEC.Combat.Initiative.ChooseCard: Choose a Card
 YZEC.Combat.Initiative.Draw: '{name}''s Initiative'
 YZEC.Combat.Initiative.DrawQty: How many Cards to Draw
 YZEC.Combat.Initiative.NotEnoughCards: Not enough cards in the initiative deck
 YZEC.Combat.Initiative.ResetDeck: Shuffled all the discarded initiative cards back into the deck
-YZEC.CombatantConfig.DrawSize: Draw Size
-YZEC.CombatantConfig.InitiativeCard: Initiative Card
-YZEC.CombatantConfig.InitiativeCardAvailable: Available
-YZEC.CombatantConfig.InitiativeCardDiscarded: Discarded
-YZEC.CombatantConfig.InitiativeCardDrawn: Drawn
-YZEC.CombatantConfig.KeepState: Keep State
-YZEC.CombatantConfig.KeepStateBest: Best
-YZEC.CombatantConfig.KeepStateWorst: Worst
-YZEC.CombatantConfig.Speed: Speed
 YZEC.CombatTracker.AddFollowers: Add Selected Tokens As Followers
 YZEC.CombatTracker.ChooseCombatant: Choose a Combatant
 YZEC.CombatTracker.DuplicateCombatant: Duplicate Combatant
@@ -65,9 +64,18 @@ YZEC.CombatTracker.SlowAction: Slow Action
 YZEC.CombatTracker.SubmitColor: Submit
 YZEC.CombatTracker.SwapInitiative: Swap Initiative
 YZEC.CombatTracker.UnfollowLeader: Unfollow {name}
-YZEC.InitiativeDeckName: Initiative Deck
+YZEC.CombatantConfig.DrawSize: Draw Size
+YZEC.CombatantConfig.InitiativeCard: Initiative Card
+YZEC.CombatantConfig.InitiativeCardAvailable: Available
+YZEC.CombatantConfig.InitiativeCardDiscarded: Discarded
+YZEC.CombatantConfig.InitiativeCardDrawn: Drawn
+YZEC.CombatantConfig.KeepState: Keep State
+YZEC.CombatantConfig.KeepStateBest: Best
+YZEC.CombatantConfig.KeepStateWorst: Worst
+YZEC.CombatantConfig.Speed: Speed
 YZEC.InitiativeDeckDiscardPileName: Initiative Cards Discard Pile
-YZEC.OK: OK
-YZEC.NoInitiativeDeckFound: No initiative deck found, creating a new one...
+YZEC.InitiativeDeckName: Initiative Deck
 YZEC.NoInitiativeDeckDiscardPileFound: No discard pile found, creating a new one...
+YZEC.NoInitiativeDeckFound: No initiative deck found, creating a new one...
+YZEC.OK: OK
 YZEC.WARNING.InvalidDeckType: You can only draw initiative cards from a deck

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -38,6 +38,7 @@ export const SETTINGS_KEYS = {
   /** @type {'initSortOrder'} */ INITIATIVE_SORT_ORDER: 'initSortOrder',
   /** @type {'maxDrawSize'} */ MAX_DRAW_SIZE: 'maxDrawSize',
   /** @type {'slowAndFastActions'} */ SLOW_AND_FAST_ACTIONS: 'slowAndFastActions',
+  /** @type {'resetEachRound'} */ RESET_EACH_ROUND: 'resetEachRound',
 };
 
 /** @enum {string} */

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -1,8 +1,8 @@
 // ? scope: world (gm), client (player)
 // ? config: true (visible)
 
-import { CARD_STACK, MODULE_ID, SETTINGS_KEYS } from './constants.js';
 import { getCombatantSortOrderModifier } from '@utils/utils.js';
+import { CARD_STACK, MODULE_ID, SETTINGS_KEYS } from './constants.js';
 
 export function registerSystemSettings() {
 
@@ -62,6 +62,15 @@ export function registerSystemSettings() {
     config: true,
     type: Boolean,
     default: true,
+  });
+
+  game.settings.register(MODULE_ID, SETTINGS_KEYS.RESET_EACH_ROUND, {
+    name: 'SETTINGS.InitiativeResetEachRound',
+    hint: 'SETTINGS.InitiativeResetEachRoundHint',
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
   });
 
   game.settings.register(MODULE_ID, SETTINGS_KEYS.INITIATIVE_MESSAGING, {

--- a/src/yze-combat.js
+++ b/src/yze-combat.js
@@ -8,25 +8,25 @@
  *
  * Foundry License: Foundry Virtual Tabletop End User License Agreement
  *   https://foundryvtt.com/article/license/
- * 
+ *
  * Greatly inspired by FloRad's SWADE's initiative cards combat system
  *   https://gitlab.com/peginc/swade
  *
  * ============================================================================
  */
 
+import YearZeroCards from '@combat/cards';
+import YearZeroCombat from '@combat/combat';
+import YearZeroCombatant from '@combat/combatant';
+import { addSlowAndFastStatusEffects } from '@combat/slow-and-fast-actions';
 import { YZEC } from '@module/config';
 import { HOOKS_KEYS, MODULE_ID, SETTINGS_KEYS } from '@module/constants';
 import { initializeHandlebars } from '@module/handlebars';
 import { registerSystemSettings } from '@module/settings';
 import { setupModule } from '@module/setup';
 import YearZeroCombatHook from '@utils/client-hooks';
-import YearZeroCards from '@combat/cards';
-import YearZeroCombat from '@combat/combat';
-import YearZeroCombatant from '@combat/combatant';
 import YearZeroCombatTracker from './sidebar/combat-tracker';
 import { onRenderCombatantConfig } from './sidebar/combatant-config';
-import { addSlowAndFastStatusEffects } from '@combat/slow-and-fast-actions';
 
 /* ------------------------------------------ */
 /*  Foundry VTT Initialization                */
@@ -72,8 +72,6 @@ Hooks.once('ready', async () => {
 
   // Calls the configuration hook.
   Hooks.callAll(HOOKS_KEYS.YZEC_READY, YearZeroCombatHook);
-
-  // TODO Remove this example before merge
 
   // // This listens for a message from the client called when the user clicks the slow button in the combat tracker.
   // Hooks.on(`${MODULE_ID}.slow-action-button-clicked`, data => {


### PR DESCRIPTION
## Summary
This PR adds a feature that accomodates Dragonbane's Initiative system. The feature is toggled through a Settings checkbox that enables it's functionality.

The core functionality is simply to reset initiative on each round.

In addition to this having the following settings enabled adds further functionality:

- Automatically Reset Initiative Deck will ensure the Initiative Deck is reset at the start of the round.
- Automatically Draw Initiative will ensure that initiative is drawn at the start of each round.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
