### PR TITLE
Feat: Add 'Lock Initiative' button

### DIFF
--- a/src/combat/combat.js
+++ b/src/combat/combat.js
@@ -71,10 +71,16 @@ export default class YearZeroCombat extends Combat {
       if (cards.length > 1) {
         cards.sort((a, b) => (a.value - b.value) * Utils.getCardSortOrderModifier(combatant.keepState));
 
-        if (game.settings.get(MODULE_ID, SETTINGS_KEYS.AUTO_SELECT_BEST_CARD)) {card = cards[0];}
-        else card = await this.chooseCard(cards, combatant);
+        if (game.settings.get(MODULE_ID, SETTINGS_KEYS.AUTO_SELECT_BEST_CARD)) {
+          card = cards[0];
+        }
+        else {
+          card = await this.chooseCard(cards, combatant);
+        }
       }
-      else {card = cards[0];}
+      else {
+        card = cards[0];
+      }
 
 
       // Updates the combatant.

--- a/src/combat/combat.js
+++ b/src/combat/combat.js
@@ -46,7 +46,7 @@ export default class YearZeroCombat extends Combat {
       const inGroup = !!combatant.groupId;
       const isRedraw = !!combatant.initiative;
 
-      if (combatant.isDefeated || inGroup || combatant.lockInitiative) continue;
+      if (combatant.isDefeated || inGroup) continue;
 
       // Checks if enough cards are available.
       const cardsToDraw = combatant.getNumberOfCardsToDraw();
@@ -71,16 +71,11 @@ export default class YearZeroCombat extends Combat {
       if (cards.length > 1) {
         cards.sort((a, b) => (a.value - b.value) * Utils.getCardSortOrderModifier(combatant.keepState));
 
-        if (game.settings.get(MODULE_ID, SETTINGS_KEYS.INITIATIVE_AUTODRAW)) {
-          card = cards[0];
-        }
-        else {
-          card = await this.chooseCard(cards, combatant);
-        }
+        if (game.settings.get(MODULE_ID, SETTINGS_KEYS.AUTO_SELECT_BEST_CARD)) {card = cards[0];}
+        else card = await this.chooseCard(cards, combatant);
       }
-      else {
-        card = cards[0];
-      }
+      else {card = cards[0];}
+
 
       // Updates the combatant.
       const updateData = {
@@ -354,8 +349,8 @@ export default class YearZeroCombat extends Combat {
     // Proceed to previous round.
     await super.previousRound();
 
+    // Check if state exists for this round and restore it.
     const roundState = this.history[this.round];
-
     if (roundState) {
       await this.update({ ['combatants']: roundState }, { diff: false });
     }
@@ -380,6 +375,8 @@ export default class YearZeroCombat extends Combat {
     };
     return AudioHelper.play(data);
   }
+
+  /* ------------------------------------------ */
 
   /**
    * Resets the initiative of all combatants at the start of the round. Optionally resets the initiative deck,

--- a/src/combat/combatant.js
+++ b/src/combat/combatant.js
@@ -147,6 +147,7 @@ export default class YearZeroCombatant extends Combatant {
    */
   getNumberOfCardsToDraw() {
     // TODO add talents here, if any.
+    if (this.lockInitiative) return 0;
     return this.drawSize;
   }
 

--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -12,7 +12,11 @@ SETTINGS.ActorSpeedAttributeHint: >-
   The property key in the actor's data to the attribute that defines how many
   initiative cards are kept (speed) by the combatant (e.g. system.speed.value).
 SETTINGS.AutoDraw: Automatic Initiative Draw
-SETTINGS.AutoDrawHint: Whether to automatically draw initiative cards.
+SETTINGS.AutoDrawHint: Whether to automatically draw initiative cards when combat starts.
+SETTINGS.AutoSelectBestCard: Choose Best Card
+SETTINGS.AutoSelectBestCardHint: >-
+  Forgo the card selection dialog on multiple drawn initiative cards, instead opting for
+  the best (fastest) initiative card.
 SETTINGS.DiscardPile: Discard Pile ID
 SETTINGS.DiscardPileHint: ID or name of the Discard pile where to put the drawn initiative cards.
 SETTINGS.DuplicateCombatantsOnCombatStart: Duplicate Combatants
@@ -55,7 +59,6 @@ YZEC.CombatTracker.FastAction: Fast Action
 YZEC.CombatTracker.FollowLeader: Follow {name}
 YZEC.CombatTracker.GroupLeader: Group Leader
 YZEC.CombatTracker.InitiativeDeckReset: Reset Initiative Deck
-YZEC.CombatTracker.lockInitiative: Lock Initiative
 YZEC.CombatTracker.MakeGroupLeader: Make Group Leader
 YZEC.CombatTracker.RemoveGroupLeader: Remove Group Leader
 YZEC.CombatTracker.ResetColor: Reset
@@ -65,6 +68,7 @@ YZEC.CombatTracker.SlowAction: Slow Action
 YZEC.CombatTracker.SubmitColor: Submit
 YZEC.CombatTracker.SwapInitiative: Swap Initiative
 YZEC.CombatTracker.UnfollowLeader: Unfollow {name}
+YZEC.CombatTracker.lockInitiative: Lock Initiative
 YZEC.CombatantConfig.DrawSize: Draw Size
 YZEC.CombatantConfig.InitiativeCard: Initiative Card
 YZEC.CombatantConfig.InitiativeCardAvailable: Available

--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -55,6 +55,7 @@ YZEC.CombatTracker.FastAction: Fast Action
 YZEC.CombatTracker.FollowLeader: Follow {name}
 YZEC.CombatTracker.GroupLeader: Group Leader
 YZEC.CombatTracker.InitiativeDeckReset: Reset Initiative Deck
+YZEC.CombatTracker.lockInitiative: Lock Initiative
 YZEC.CombatTracker.MakeGroupLeader: Make Group Leader
 YZEC.CombatTracker.RemoveGroupLeader: Remove Group Leader
 YZEC.CombatTracker.ResetColor: Reset

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -29,6 +29,16 @@ YZEC.CombatTracker = {
         visibility: 'owner',
       },
     ],
+    lockInitiative: [
+      {
+        eventName: 'lock-initiative-button-clicked',
+        label: 'YZEC.CombatTracker.lockInitiative',
+        icon: 'fas fa-lock',
+        id: 'lock-initiative-button',
+        property: 'lockInitiative',
+        visibility: 'owner',
+      },
+    ],
   },
 };
 

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -37,6 +37,11 @@ YZEC.CombatTracker = {
         id: 'lock-initiative-button',
         property: 'lockInitiative',
         visibility: 'owner',
+        condition: (combat, combatant) => {
+          const combatHasBegun = combat.active && combat.started;
+          const notInGroup = !combatant.groupId;
+          return combatHasBegun && notInGroup;
+        },
       },
     ],
   },

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -39,6 +39,7 @@ export const SETTINGS_KEYS = {
   /** @type {'maxDrawSize'} */ MAX_DRAW_SIZE: 'maxDrawSize',
   /** @type {'slowAndFastActions'} */ SLOW_AND_FAST_ACTIONS: 'slowAndFastActions',
   /** @type {'resetEachRound'} */ RESET_EACH_ROUND: 'resetEachRound',
+  /** @type {'autoSelectBestCard'} */ AUTO_SELECT_BEST_CARD: 'autoSelectBestCard',
 };
 
 /** @enum {string} */

--- a/src/module/handlebars.js
+++ b/src/module/handlebars.js
@@ -85,6 +85,12 @@ function registerHandlebarsHelpers() {
   // Handlebars.registerHelper('ratio', function (a, b) {
   //   return (a / b) * 100;
   // });
+
+  Handlebars.registerHelper('test', function (...args) {
+    const [cb, ...params] = args;
+    if (typeof cb !== 'function') return true;
+    return !!cb(...params);
+  });
 }
 
 export function initializeHandlebars() {

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -71,6 +71,7 @@ export function registerSystemSettings() {
     config: true,
     type: Boolean,
     default: false,
+    requiresReload: true,
   });
 
   game.settings.register(MODULE_ID, SETTINGS_KEYS.AUTO_SELECT_BEST_CARD, {

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -73,6 +73,15 @@ export function registerSystemSettings() {
     default: false,
   });
 
+  game.settings.register(MODULE_ID, SETTINGS_KEYS.AUTO_SELECT_BEST_CARD, {
+    name: 'SETTINGS.AutoSelectBestCard',
+    hint: 'SETTINGS.AutoSelectBestCardHint',
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+
   game.settings.register(MODULE_ID, SETTINGS_KEYS.INITIATIVE_MESSAGING, {
     name: 'SETTINGS.InitiativeMessaging',
     hint: 'SETTINGS.InitiativeMessagingHint',

--- a/src/templates/sidebar/combat-tracker.hbs
+++ b/src/templates/sidebar/combat-tracker.hbs
@@ -1,9 +1,11 @@
 {{! Defines a partial that is used below to iterate over various button contexts}}
 {{#*inline "buttonPartial"}}
 	{{#each buttons}}
-		<a class="combatant-control {{#if (lookup ../combatant property)}}active{{/if}}" id={{id}} data-event={{eventName}}
-			data-property="{{property}}" data-tooltip="{{localize label}}">
-			<i class="fas {{icon}}"></i></a>
+		{{#if (test condition @root.combat ../combatant)}}
+			<a class="combatant-control {{#if (lookup ../combatant property)}}active{{/if}}" id={{id}} data-event={{eventName}}
+				data-property="{{property}}" data-tooltip="{{localize label}}">
+				<i class="fas {{icon}}"></i></a>
+		{{/if}}
 	{{/each}}
 {{/inline}}
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -40,10 +40,14 @@ export function getInitiativeDeckDiscardPile(strict = false) {
  * and shuffles them back into the initiative deck.
  * @param {boolean} [chatNotification=false] Whether to send a chat notification.
  */
-export async function resetInitiativeDeck(chatNotification = false) {
+export async function resetInitiativeDeck(chatNotification = false, toExclude = []) {
   const initiativeDeck = getInitiativeDeck(true);
-  await initiativeDeck.recall({ chatNotification });
+  const discardPile = getInitiativeDeckDiscardPile(true);
+  const toRecall = discardPile.cards.filter(c => !toExclude.includes(c.value)).map(c => c.id);
+
+  await discardPile.pass(initiativeDeck, toRecall, { chatNotification });
   await initiativeDeck.shuffle({ chatNotification });
+
   ui.notifications.info('YZEC.Combat.Initiative.ResetDeck', { localize: true });
 }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -39,6 +39,7 @@ export function getInitiativeDeckDiscardPile(strict = false) {
  * Recalls all the discarded initiative cards
  * and shuffles them back into the initiative deck.
  * @param {boolean} [chatNotification=false] Whether to send a chat notification.
+ * @param {number[]} [toExclude=[]] Array of card values to exclude from the reset.
  */
 export async function resetInitiativeDeck(chatNotification = false, toExclude = []) {
   const initiativeDeck = getInitiativeDeck(true);


### PR DESCRIPTION
## Summary
After some consideration, I believe the cleanest way to allow users to use functionality like the 'Veteran'-ability in Dragonbane is to implement it in Year Zero Combat itself (it requires changing how some internal methods execute and we cannot expose that in a configurable manner).

The buttons for locking initiative will now appear by default when 'Reset the Initiative Each Round' is selected.

The resetInitiativeDeck has seen some change in it's functionality as a result. Instead of using 'recall' we now use 'pass' and supply a filtered list of cards this allows us to keep the initiative cards we want to keep between draws in the discard pile.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR fixes an issue https://github.com/pafvel/dragonbane/issues/7.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
