### PR TITLE
feat: ✨ add a single-action mode for combat tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Combatant cloning is supported *(one token can have multiple initiative entries in a combat instance, useful for monsters with Speed > 1)*
 - Redrawing initiative at the start of each round is supported
 - Swap initiative cards between two combatants
-- Buttons for Fast and Slow actions
+- Buttons for actions (single or fast/slow)
 - Combatant configuration *(how many cards to draw, keep best or worst, etc.)*
 - Module settings *(everything is customizable by the GM)*
 - Developer options for customization

--- a/src/combat/combat.js
+++ b/src/combat/combat.js
@@ -305,7 +305,9 @@ export default class YearZeroCombat extends Combat {
   /** @override */
   async endCombat() {
     const toEnd = await super.endCombat();
-    if (toEnd && game.settings.get(MODULE_ID, SETTINGS_KEYS.SLOW_AND_FAST_ACTIONS)) {
+    const slowAndFastActions = game.settings.get(MODULE_ID, SETTINGS_KEYS.SLOW_AND_FAST_ACTIONS);
+    const singleAction = game.settings.get(MODULE_ID, SETTINGS_KEYS.SINGLE_ACTION);
+    if (toEnd && (slowAndFastActions || singleAction)) {
       await this.#removeAllFastAndSlowActions();
     }
   }
@@ -329,7 +331,9 @@ export default class YearZeroCombat extends Combat {
     await super.nextRound();
 
     // Remove slow and fast actions if enabled.
-    if (game.settings.get(MODULE_ID, SETTINGS_KEYS.SLOW_AND_FAST_ACTIONS)) {
+    const slowAndFastActions = game.settings.get(MODULE_ID, SETTINGS_KEYS.SLOW_AND_FAST_ACTIONS);
+    const singleAction = game.settings.get(MODULE_ID, SETTINGS_KEYS.SINGLE_ACTION);
+    if (slowAndFastActions || singleAction) {
       await this.#removeAllFastAndSlowActions();
     }
 
@@ -423,7 +427,11 @@ export default class YearZeroCombat extends Combat {
   }
 
   static async #removeSlowAndFastActions(token) {
-    return Promise.all([STATUS_EFFECTS.FAST_ACTION, STATUS_EFFECTS.SLOW_ACTION].map(async effect =>
+    return Promise.all([
+      STATUS_EFFECTS.FAST_ACTION,
+      STATUS_EFFECTS.SLOW_ACTION,
+      STATUS_EFFECTS.SINGLE_ACTION,
+    ].map(async effect =>
       await token.toggleActiveEffect({ id: effect }, { active: false }),
     ));
   }

--- a/src/combat/slow-and-fast-actions.js
+++ b/src/combat/slow-and-fast-actions.js
@@ -3,3 +3,7 @@ import { YZEC } from '@module/config';
 export function addSlowAndFastStatusEffects() {
   CONFIG.statusEffects.push(...YZEC.StatusEffects.slowAndFastActions);
 }
+
+export function addSingleActionStatusEffect() {
+  CONFIG.statusEffects.push(YZEC.StatusEffects.singleAction);
+}

--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -47,6 +47,9 @@ SETTINGS.SlowAndFastActions: Enable Slow & Fast Actions
 SETTINGS.SlowAndFastActionsHint: >-
   Whether to show additional buttons for Slow & Fast Actions in the Combat
   Tracker.
+SETTINGS.SingleAction: Enable Single Action
+SETTINGS.SingleActionHint: >-
+  Whether to show a button for a single action in the Combat Tracker, for e.g. Dragonbane.
 YZEC.Combat.Initiative.ChooseCard: Choose a Card
 YZEC.Combat.Initiative.Draw: '{name}''s Initiative'
 YZEC.Combat.Initiative.DrawQty: How many Cards to Draw
@@ -64,6 +67,7 @@ YZEC.CombatTracker.RemoveGroupLeader: Remove Group Leader
 YZEC.CombatTracker.ResetColor: Reset
 YZEC.CombatTracker.SelectColor: Select Color
 YZEC.CombatTracker.SetGroupColor: Set Group Color
+YZEC.CombatTracker.SingleAction: Action
 YZEC.CombatTracker.SlowAction: Slow Action
 YZEC.CombatTracker.SubmitColor: Submit
 YZEC.CombatTracker.SwapInitiative: Swap Initiative

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -29,6 +29,16 @@ YZEC.CombatTracker = {
         visibility: 'owner',
       },
     ],
+    singleAction: [
+      {
+        eventName: 'single-action-button-clicked',
+        icon: 'fa-play',
+        id: 'single-action-button',
+        property: 'action',
+        label: 'YZEC.CombatTracker.SingleAction',
+        visibility: 'owner',
+      },
+    ],
     lockInitiative: [
       {
         eventName: 'lock-initiative-button-clicked',
@@ -75,6 +85,12 @@ YZEC.StatusEffects = {
       statuses: ['slowAction'],
     },
   ],
+  singleAction: {
+    id: STATUS_EFFECTS.SINGLE_ACTION,
+    label: 'YZEC.CombatTracker.SingleAction',
+    icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+    statuses: ['action'],
+  },
 };
 
 /* ------------------------------------------ */

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -18,6 +18,7 @@ export const CARD_STACK = {
 export const STATUS_EFFECTS = {
   FAST_ACTION: 'fastAction',
   SLOW_ACTION: 'slowAction',
+  SINGLE_ACTION: 'action',
 };
 
 /** @enum {string} */
@@ -38,6 +39,7 @@ export const SETTINGS_KEYS = {
   /** @type {'initSortOrder'} */ INITIATIVE_SORT_ORDER: 'initSortOrder',
   /** @type {'maxDrawSize'} */ MAX_DRAW_SIZE: 'maxDrawSize',
   /** @type {'slowAndFastActions'} */ SLOW_AND_FAST_ACTIONS: 'slowAndFastActions',
+  /** @type {'singleAction'} */ SINGLE_ACTION: 'singleAction',
   /** @type {'resetEachRound'} */ RESET_EACH_ROUND: 'resetEachRound',
   /** @type {'autoSelectBestCard'} */ AUTO_SELECT_BEST_CARD: 'autoSelectBestCard',
 };

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -102,6 +102,16 @@ export function registerSystemSettings() {
     requiresReload: true,
   });
 
+  game.settings.register(MODULE_ID, SETTINGS_KEYS.SINGLE_ACTION, {
+    name: 'SETTINGS.SingleAction',
+    hint: 'SETTINGS.SingleActionHint',
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+    requiresReload: true,
+  });
+
   game.settings.register(MODULE_ID, SETTINGS_KEYS.DUPLICATE_COMBATANTS_ON_START, {
     name: 'SETTINGS.DuplicateCombatantsOnCombatStart',
     hint: 'SETTINGS.DuplicateCombatantsOnCombatStartHint',

--- a/src/sidebar/combat-tracker.js
+++ b/src/sidebar/combat-tracker.js
@@ -280,7 +280,7 @@ export default class YearZeroCombatTracker extends CombatTracker {
       event: eventName,
       origin: btn,
     };
-    if (property === 'slowAction' || property === 'fastAction') {
+    if (property === 'slowAction' || property === 'fastAction' || property === 'action') {
       const effect = CONFIG.statusEffects.find(e => e.id === property);
       const active = !combatant[property];
       if (!active) await combatant.unsetFlag(MODULE_ID, property);
@@ -448,6 +448,9 @@ export default class YearZeroCombatTracker extends CombatTracker {
         if (game.settings.get(MODULE_ID, SETTINGS_KEYS.SLOW_AND_FAST_ACTIONS)) {
           cfg.buttons.unshift(...YZEC.CombatTracker.DefaultCombatantControls.slowAndFastActions);
         }
+        else if (game.settings.get(MODULE_ID, SETTINGS_KEYS.SINGLE_ACTION)) {
+          cfg.buttons.unshift(...YZEC.CombatTracker.DefaultCombatantControls.singleAction);
+        }
 
         if (game.settings.get(MODULE_ID, SETTINGS_KEYS.RESET_EACH_ROUND)) {
           cfg.buttons.unshift(...YZEC.CombatTracker.DefaultCombatantControls.lockInitiative);
@@ -490,6 +493,7 @@ export default class YearZeroCombatTracker extends CombatTracker {
     // FIXME: Figure out why these turn up as flags.
     delete flags.fastAction;
     delete flags.slowAction;
+    delete flags.action;
     const statuses = combatant.actor?.statuses.reduce((acc, s) => {
       acc[s] = true;
       return acc;

--- a/src/yze-combat.js
+++ b/src/yze-combat.js
@@ -18,7 +18,7 @@
 import YearZeroCards from '@combat/cards';
 import YearZeroCombat from '@combat/combat';
 import YearZeroCombatant from '@combat/combatant';
-import { addSlowAndFastStatusEffects } from '@combat/slow-and-fast-actions';
+import { addSlowAndFastStatusEffects, addSingleActionStatusEffect } from '@combat/slow-and-fast-actions';
 import { YZEC } from '@module/config';
 import { HOOKS_KEYS, MODULE_ID, SETTINGS_KEYS } from '@module/constants';
 import { initializeHandlebars } from '@module/handlebars';
@@ -66,6 +66,9 @@ Hooks.once('ready', async () => {
   }
   if (game.settings.get(MODULE_ID, SETTINGS_KEYS.SLOW_AND_FAST_ACTIONS)) {
     addSlowAndFastStatusEffects();
+  }
+  if (game.settings.get(MODULE_ID, SETTINGS_KEYS.SINGLE_ACTION)) {
+    addSingleActionStatusEffect();
   }
 
   console.log('YZEC | Ready!');


### PR DESCRIPTION
## Summary
This mimics the slow-and-fast-actions settings option to provide a Dragonbane-friendly setup with a single action button.

![CleanShot 2024-02-04 at 11 47 51](https://github.com/fvtt-fria-ligan/yearzero-combat-fvtt/assets/39902/f76f3199-0088-4d5a-8c88-4b5f7fb5d216)
![CleanShot 2024-02-04 at 11 46 32](https://github.com/fvtt-fria-ligan/yearzero-combat-fvtt/assets/39902/e788c700-d7e4-4a5d-8af5-10b8cbc19624)
![CleanShot 2024-02-04 at 11 45 55](https://github.com/fvtt-fria-ligan/yearzero-combat-fvtt/assets/39902/21a311e1-d924-47cc-933e-dda355f879de) 

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
