### PR TITLE
fix: 🐛 removes error when toggling status effect

### DIFF
--- a/src/combat/combat.js
+++ b/src/combat/combat.js
@@ -427,11 +427,13 @@ export default class YearZeroCombat extends Combat {
   }
 
   static async #removeSlowAndFastActions(token) {
-    return Promise.all([
+    const effects = [
       STATUS_EFFECTS.FAST_ACTION,
       STATUS_EFFECTS.SLOW_ACTION,
       STATUS_EFFECTS.SINGLE_ACTION,
-    ].map(async effect =>
+    ].filter(action => CONFIG.statusEffects.find(e => e.id === action));
+
+    return Promise.all(effects.map(async effect =>
       await token.toggleActiveEffect({ id: effect }, { active: false }),
     ));
   }


### PR DESCRIPTION
Resolves #42 

## Summary
In v12 toggleActiveEffect  throws an error if the status effect doesn't exist in CONFIG.statusEffects. This change ensures that only status effects that exist in CONFIG.statusEffects are toggled.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [ x ] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ x ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
