### PR TITLE
fix: 🐛 Single action mode for actors with speed > 1 

### DIFF
--- a/src/combat/combat.js
+++ b/src/combat/combat.js
@@ -308,7 +308,7 @@ export default class YearZeroCombat extends Combat {
     const slowAndFastActions = game.settings.get(MODULE_ID, SETTINGS_KEYS.SLOW_AND_FAST_ACTIONS);
     const singleAction = game.settings.get(MODULE_ID, SETTINGS_KEYS.SINGLE_ACTION);
     if (toEnd && (slowAndFastActions || singleAction)) {
-      await this.#removeAllFastAndSlowActions();
+      await this.#removeAllActions();
     }
   }
 
@@ -334,7 +334,7 @@ export default class YearZeroCombat extends Combat {
     const slowAndFastActions = game.settings.get(MODULE_ID, SETTINGS_KEYS.SLOW_AND_FAST_ACTIONS);
     const singleAction = game.settings.get(MODULE_ID, SETTINGS_KEYS.SINGLE_ACTION);
     if (slowAndFastActions || singleAction) {
-      await this.#removeAllFastAndSlowActions();
+      await this.#removeAllActions();
     }
 
     return this;
@@ -421,20 +421,38 @@ export default class YearZeroCombat extends Combat {
    * @returns {Promise.<void>}
    * @async
    */
-  async #removeAllFastAndSlowActions() {
+  async #removeAllActions() {
     const tokens = Array.from(new Set(this.combatants.map(c => c.token)));
     Promise.all(tokens.map(async c => await YearZeroCombat.#removeSlowAndFastActions(c)));
+    Promise.all(tokens.map(async c => await YearZeroCombat.#removeSingleActions(c)));
   }
 
   static async #removeSlowAndFastActions(token) {
     const effects = [
       STATUS_EFFECTS.FAST_ACTION,
       STATUS_EFFECTS.SLOW_ACTION,
-      STATUS_EFFECTS.SINGLE_ACTION,
     ].filter(action => CONFIG.statusEffects.find(e => e.id === action));
 
     return Promise.all(effects.map(async effect =>
-      await token.toggleActiveEffect({ id: effect }, { active: false }),
+      await token.actor.toggleStatusEffect(effect, { active: false }),
+    ));
+  }
+
+  static async #removeSingleActions(token) {
+    const effects = [
+      STATUS_EFFECTS.SINGLE_ACTION_1,
+      STATUS_EFFECTS.SINGLE_ACTION_2,
+      STATUS_EFFECTS.SINGLE_ACTION_3,
+      STATUS_EFFECTS.SINGLE_ACTION_4,
+      STATUS_EFFECTS.SINGLE_ACTION_5,
+      STATUS_EFFECTS.SINGLE_ACTION_6,
+      STATUS_EFFECTS.SINGLE_ACTION_7,
+      STATUS_EFFECTS.SINGLE_ACTION_8,
+      STATUS_EFFECTS.SINGLE_ACTION_9,
+    ].filter(action => CONFIG.statusEffects.find(e => e.id === action));
+
+    return Promise.all(effects.map(async effect =>
+      await token.actor.toggleStatusEffect(effect, { active: false }),
     ));
   }
 

--- a/src/combat/combatant.js
+++ b/src/combat/combatant.js
@@ -272,7 +272,7 @@ export default class YearZeroCombatant extends Combatant {
   /** @override */
   static async _preUpdateOperation(_documents, operation, _user) {
     await super._preUpdateOperation(_documents, operation, _user);
-    if (operation.turnEvents === false) {
+    if (operation.turnEvents === false && operation.combatTurn) {
       delete operation.combatTurn;
     }
   }

--- a/src/combat/combatant.js
+++ b/src/combat/combatant.js
@@ -272,7 +272,7 @@ export default class YearZeroCombatant extends Combatant {
   /** @override */
   static async _preUpdateOperation(_documents, operation, _user) {
     await super._preUpdateOperation(_documents, operation, _user);
-    if (operation.turnEvents === false && operation.combatTurn) {
+    if (operation.turnEvents === false) {
       delete operation.combatTurn;
     }
   }

--- a/src/combat/combatant.js
+++ b/src/combat/combatant.js
@@ -230,8 +230,10 @@ export default class YearZeroCombatant extends Combatant {
 
   /* ------------------------------------------ */
   #getSingleActionStatus(combatant) {
-    const as = combatant.combat.turns.filter(t => t.tokenId === combatant.tokenId);
-    for (let i = 0; i < as.length && i < YZEC.StatusEffects.singleAction.length; i++) {
+    const as = combatant.combat.turns
+      .filter(t => t.tokenId === combatant.tokenId)
+      .slice(0, YZEC.StatusEffects.singleAction.length);
+    for (let i = 0; i < as.length; i++) {
       as[i] = {
         id: as[i].id,
         action: as[i].token.hasStatusEffect(YZEC.StatusEffects.singleAction[i].id),
@@ -244,6 +246,7 @@ export default class YearZeroCombatant extends Combatant {
     const post = this.#getSingleActionStatus(combatant);
     for (let i = 0; i < post.length; i++) {
       const preIndex = preCombatantActions.findIndex(e => e.id === post[i].id);
+      if (preIndex < 0) continue;
       const preAction = preCombatantActions[preIndex].action;
       const postAction = post[i].action;
       if (preAction != postAction) {

--- a/src/combat/combatant.js
+++ b/src/combat/combatant.js
@@ -269,14 +269,6 @@ export default class YearZeroCombatant extends Combatant {
     return this.combat.updateEmbeddedDocuments('Combatant', updates, { turnEvents: false });
   }
 
-  /** @override */
-  static async _preUpdateOperation(_documents, operation, _user) {
-    await super._preUpdateOperation(_documents, operation, _user);
-    if (operation.turnEvents === false && operation.combatTurn) {
-      delete operation.combatTurn;
-    }
-  }
-
   /* ------------------------------------------ */
   /*  Combatant Creation                        */
   /* ------------------------------------------ */

--- a/src/combat/combatant.js
+++ b/src/combat/combatant.js
@@ -269,6 +269,14 @@ export default class YearZeroCombatant extends Combatant {
     return this.combat.updateEmbeddedDocuments('Combatant', updates, { turnEvents: false });
   }
 
+  /** @override */
+  static async _preUpdateOperation(_documents, operation, _user) {
+    await super._preUpdateOperation(_documents, operation, _user);
+    if (operation.turnEvents === false && operation.combatTurn) {
+      delete operation.combatTurn;
+    }
+  }
+
   /* ------------------------------------------ */
   /*  Combatant Creation                        */
   /* ------------------------------------------ */

--- a/src/combat/slow-and-fast-actions.js
+++ b/src/combat/slow-and-fast-actions.js
@@ -1,9 +1,23 @@
 import { YZEC } from '@module/config';
+import { MODULE_ID, SETTINGS_KEYS } from '@module/constants';
 
 export function addSlowAndFastStatusEffects() {
   CONFIG.statusEffects.push(...YZEC.StatusEffects.slowAndFastActions);
 }
 
 export function addSingleActionStatusEffect() {
-  CONFIG.statusEffects.push(YZEC.StatusEffects.singleAction);
+  CONFIG.statusEffects.push(...YZEC.StatusEffects.singleAction);
+}
+
+export function onRenderTokenHUD(_app, html, options) {
+  const key = game.settings.get(MODULE_ID, SETTINGS_KEYS.ACTOR_SPEED_ATTRIBUTE);
+  const speed = foundry.utils.getProperty(options.delta, key)
+  || foundry.utils.getProperty(game.actors.get(options.actorId), key)
+  || 1;
+
+  // Remove unused single action status effects from HUD
+  for (let i = 1 + speed; i <= 9; i++) {
+    const effects = html.find(`.effect-control[data-status-id="action${i}"]`);
+    effects.remove();
+  }
 }

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -7,6 +7,16 @@ import { CARDS_DRAW_KEEP_STATES, MODULE_ID, STATUS_EFFECTS } from './constants.j
  */
 export const YZEC = {};
 
+function singleActionCondition(combat, combatant, index) {
+  const tokenId = combat.combatants.get(combatant.id).tokenId;
+  let action = 0;
+  for (const turn of combat.turns) {
+    if (turn.tokenId === tokenId) action++;
+    if (turn.id === combatant.id) break;
+  }
+  return action === index;
+}
+
 YZEC.CombatTracker = {
   src: `modules/${MODULE_ID}/sidebar/combat-tracker.config.json`,
   // config: undefined,
@@ -31,12 +41,85 @@ YZEC.CombatTracker = {
     ],
     singleAction: [
       {
-        eventName: 'single-action-button-clicked',
+        eventName: 'single-action-button-1-clicked',
         icon: 'fa-play',
-        id: 'single-action-button',
-        property: 'action',
+        id: 'single-action-button-1',
+        property: 'action1',
         label: 'YZEC.CombatTracker.SingleAction',
         visibility: 'owner',
+        condition: (combat, combatant) => singleActionCondition(combat, combatant, 1),
+      },
+      {
+        eventName: 'single-action-button-2-clicked',
+        icon: 'fa-play',
+        id: 'single-action-button-2',
+        property: 'action2',
+        label: 'YZEC.CombatTracker.SingleAction',
+        visibility: 'owner',
+        condition: (combat, combatant) => singleActionCondition(combat, combatant, 2),
+      },
+      {
+        eventName: 'single-action-button-3-clicked',
+        icon: 'fa-play',
+        id: 'single-action-button-3',
+        property: 'action3',
+        label: 'YZEC.CombatTracker.SingleAction',
+        visibility: 'owner',
+        condition: (combat, combatant) => singleActionCondition(combat, combatant, 3),
+      },
+      {
+        eventName: 'single-action-button-4-clicked',
+        icon: 'fa-play',
+        id: 'single-action-button-4',
+        property: 'action4',
+        label: 'YZEC.CombatTracker.SingleAction',
+        visibility: 'owner',
+        condition: (combat, combatant) => singleActionCondition(combat, combatant, 4),
+      },
+      {
+        eventName: 'single-action-button-5-clicked',
+        icon: 'fa-play',
+        id: 'single-action-button-5',
+        property: 'action5',
+        label: 'YZEC.CombatTracker.SingleAction',
+        visibility: 'owner',
+        condition: (combat, combatant) => singleActionCondition(combat, combatant, 5),
+      },
+      {
+        eventName: 'single-action-button-6-clicked',
+        icon: 'fa-play',
+        id: 'single-action-button-6',
+        property: 'action6',
+        label: 'YZEC.CombatTracker.SingleAction',
+        visibility: 'owner',
+        condition: (combat, combatant) => singleActionCondition(combat, combatant, 6),
+      },
+      {
+        eventName: 'single-action-button-7-clicked',
+        icon: 'fa-play',
+        id: 'single-action-button-7',
+        property: 'action7',
+        label: 'YZEC.CombatTracker.SingleAction',
+        visibility: 'owner',
+        condition: (combat, combatant) => singleActionCondition(combat, combatant, 7),
+      },
+      {
+        eventName: 'single-action-button-8-clicked',
+        icon: 'fa-play',
+        id: 'single-action-button-8',
+        property: 'action8',
+        label: 'YZEC.CombatTracker.SingleAction',
+        visibility: 'owner',
+        condition: (combat, combatant) => singleActionCondition(combat, combatant, 8),
+      },
+      {
+        eventName: 'single-action-button-9-clicked',
+        icon: 'fa-play',
+        id: 'single-action-button-9',
+        property: 'action9',
+        label: 'YZEC.CombatTracker.SingleAction',
+        visibility: 'owner',
+        condition: (combat, combatant) => singleActionCondition(combat, combatant, 9),
       },
     ],
     lockInitiative: [
@@ -85,12 +168,62 @@ YZEC.StatusEffects = {
       statuses: ['slowAction'],
     },
   ],
-  singleAction: {
-    id: STATUS_EFFECTS.SINGLE_ACTION,
-    label: 'YZEC.CombatTracker.SingleAction',
-    icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
-    statuses: ['action'],
-  },
+  singleAction: [
+    {
+      id: STATUS_EFFECTS.SINGLE_ACTION_1,
+      label: 'YZEC.CombatTracker.SingleAction',
+      icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+      statuses: ['action1'],
+    },
+    {
+      id: STATUS_EFFECTS.SINGLE_ACTION_2,
+      label: 'YZEC.CombatTracker.SingleAction',
+      icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+      statuses: ['action2'],
+    },
+    {
+      id: STATUS_EFFECTS.SINGLE_ACTION_3,
+      label: 'YZEC.CombatTracker.SingleAction',
+      icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+      statuses: ['action3'],
+    },
+    {
+      id: STATUS_EFFECTS.SINGLE_ACTION_4,
+      label: 'YZEC.CombatTracker.SingleAction',
+      icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+      statuses: ['action4'],
+    },
+    {
+      id: STATUS_EFFECTS.SINGLE_ACTION_5,
+      label: 'YZEC.CombatTracker.SingleAction',
+      icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+      statuses: ['action5'],
+    },
+    {
+      id: STATUS_EFFECTS.SINGLE_ACTION_6,
+      label: 'YZEC.CombatTracker.SingleAction',
+      icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+      statuses: ['action6'],
+    },
+    {
+      id: STATUS_EFFECTS.SINGLE_ACTION_7,
+      label: 'YZEC.CombatTracker.SingleAction',
+      icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+      statuses: ['action7'],
+    },
+    {
+      id: STATUS_EFFECTS.SINGLE_ACTION_8,
+      label: 'YZEC.CombatTracker.SingleAction',
+      icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+      statuses: ['action8'],
+    },
+    {
+      id: STATUS_EFFECTS.SINGLE_ACTION_9,
+      label: 'YZEC.CombatTracker.SingleAction',
+      icon: `modules/${MODULE_ID}/assets/icons/slow-action.svg`,
+      statuses: ['action9'],
+    },
+  ],
 };
 
 /* ------------------------------------------ */

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -18,7 +18,15 @@ export const CARD_STACK = {
 export const STATUS_EFFECTS = {
   FAST_ACTION: 'fastAction',
   SLOW_ACTION: 'slowAction',
-  SINGLE_ACTION: 'action',
+  SINGLE_ACTION_1: 'action1',
+  SINGLE_ACTION_2: 'action2',
+  SINGLE_ACTION_3: 'action3',
+  SINGLE_ACTION_4: 'action4',
+  SINGLE_ACTION_5: 'action5',
+  SINGLE_ACTION_6: 'action6',
+  SINGLE_ACTION_7: 'action7',
+  SINGLE_ACTION_8: 'action8',
+  SINGLE_ACTION_9: 'action9',
 };
 
 /** @enum {string} */

--- a/src/sidebar/combat-tracker.js
+++ b/src/sidebar/combat-tracker.js
@@ -12,7 +12,7 @@ import {
   duplicateCombatant, getCombatantsSharingToken,
 } from '@combat/duplicate-combatant';
 import { YZEC } from '@module/config';
-import { MODULE_ID, SETTINGS_KEYS } from '@module/constants';
+import { MODULE_ID, SETTINGS_KEYS, STATUS_EFFECTS } from '@module/constants';
 import { getCombatantSortOrderModifier, resetInitiativeDeck } from '@utils/utils';
 import YearZeroCombatGroupColor from '../apps/combat-group-color';
 
@@ -280,14 +280,12 @@ export default class YearZeroCombatTracker extends CombatTracker {
       event: eventName,
       origin: btn,
     };
-    if (property === 'slowAction' || property === 'fastAction' || property === 'action') {
+
+    if (Object.values(STATUS_EFFECTS).includes(property)) {
       const effect = CONFIG.statusEffects.find(e => e.id === property);
       const active = !combatant[property];
       if (!active) await combatant.unsetFlag(MODULE_ID, property);
-      await combatant.token.toggleActiveEffect(
-        { ...effect },
-        { active },
-      );
+      await combatant.token.actor.toggleStatusEffect(effect.id, { active });
     }
     else if (property) {
       await combatant.setFlag(MODULE_ID, property, !combatant.getFlag(MODULE_ID, property));
@@ -493,7 +491,15 @@ export default class YearZeroCombatTracker extends CombatTracker {
     // FIXME: Figure out why these turn up as flags.
     delete flags.fastAction;
     delete flags.slowAction;
-    delete flags.action;
+    delete flags.action1;
+    delete flags.action2;
+    delete flags.action3;
+    delete flags.action4;
+    delete flags.action5;
+    delete flags.action6;
+    delete flags.action7;
+    delete flags.action8;
+    delete flags.action9;
     const statuses = combatant.actor?.statuses.reduce((acc, s) => {
       acc[s] = true;
       return acc;

--- a/src/yze-combat.js
+++ b/src/yze-combat.js
@@ -18,7 +18,11 @@
 import YearZeroCards from '@combat/cards';
 import YearZeroCombat from '@combat/combat';
 import YearZeroCombatant from '@combat/combatant';
-import { addSlowAndFastStatusEffects, addSingleActionStatusEffect } from '@combat/slow-and-fast-actions';
+import {
+  addSlowAndFastStatusEffects,
+  addSingleActionStatusEffect,
+  onRenderTokenHUD,
+} from '@combat/slow-and-fast-actions';
 import { YZEC } from '@module/config';
 import { HOOKS_KEYS, MODULE_ID, SETTINGS_KEYS } from '@module/constants';
 import { initializeHandlebars } from '@module/handlebars';
@@ -99,3 +103,6 @@ Hooks.on('getCombatTrackerEntryContext', YearZeroCombatTracker.appendControlsToC
 Hooks.on('renderCombatantConfig', onRenderCombatantConfig);
 
 Hooks.on('createCombatant', YearZeroCombat.createCombatant);
+
+// Removes unused single action status effects from the HUD
+Hooks.on('renderTokenHUD', onRenderTokenHUD);


### PR DESCRIPTION
## Summary
Resolves https://github.com/fvtt-fria-ligan/yearzero-combat-fvtt/issues/46
Replaced toggleActiveEffect with toggleStatusEffect in all places except one (defeated status)

This change does the following:
- Replaces the single status effect for single actions with 9 numbered status effects.
- Only the effect matching the ordered per-token combatant index is shown in the sidebar.
- Only _speed_ number of effects are shown in the token hud
- When swapping initiatives, statuses are updated if the per-token combatant index is changed so that combatants retain the same status even if the are re-ordered.

## Checklist

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
