### PR TITLE
Update gulpfile.js to fix hard-coded dist dir references

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,7 +63,7 @@ async function pipeTranslations() {
   gulp
     .src('src/lang/**/*.{yml,yaml}')
     .pipe(yaml({ safe: true }))
-    .pipe(gulp.dest('./dist/lang'));
+    .pipe(gulp.dest(`${distDirectory}/lang`));
 }
 
 /* ------------------------------------------ */
@@ -103,7 +103,7 @@ function buildWatch() {
  * @async
  */
 async function cleanDist() {
-  if (fs.existsSync('./dist')) await fs.remove('./dist');
+  if (fs.existsSync(distDirectory)) await fs.remove(distDirectory);
 }
 
 /* ------------------------------------------ */


### PR DESCRIPTION
## Summary
The gulp config had a few hard-coded references to the dist directory. There is a const for this directory that's used in other locations. This PR simply unifies on using the const instead of the hard-coded values.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
