### PR TITLE
feat: Ambushed toggle makes ambushed combatants go last in the round

### DIFF
--- a/src/combat/combat.js
+++ b/src/combat/combat.js
@@ -81,11 +81,12 @@ export default class YearZeroCombat extends Combat {
         card = cards[0];
       }
 
+      const ambushedModifier = combatant.ambushed ? initiativeDeck?.cards?.size : 0;
 
       // Updates the combatant.
       const updateData = {
-        initiative: card.value,
-        [`flags.${MODULE_ID}.cardValue`]: card.value,
+        initiative: card.value + ambushedModifier,
+        [`flags.${MODULE_ID}.cardValue`]: card.value + ambushedModifier,
         [`flags.${MODULE_ID}.cardName`]: card.description || card.name,
       };
       updates.push({ _id: combatant.id, ...updateData });

--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -43,6 +43,11 @@ SETTINGS.InitiativeSortOrderDescending: Descending (Highest first)
 SETTINGS.InitiativeSortOrderHint: Default sort order for initiative.
 SETTINGS.MaxDrawSize: Maximum Draw Size
 SETTINGS.MaxDrawSizeHint: Maximum number of cards that can be drawn at once by a single combatant.
+SETTINGS.ShowAmbushed: Enable Ambushed button
+SETTINGS.ShowAmbushedHint: >-
+  Whether to show an additional button for Ambushed characters in the Combat Tracker.
+  Ambushed characters get the initiative deck size added to their initiative number
+  and therefore act last in the round.
 SETTINGS.SlowAndFastActions: Enable Slow & Fast Actions
 SETTINGS.SlowAndFastActionsHint: >-
   Whether to show additional buttons for Slow & Fast Actions in the Combat
@@ -56,6 +61,7 @@ YZEC.Combat.Initiative.DrawQty: How many Cards to Draw
 YZEC.Combat.Initiative.NotEnoughCards: Not enough cards in the initiative deck
 YZEC.Combat.Initiative.ResetDeck: Shuffled all the discarded initiative cards back into the deck
 YZEC.CombatTracker.AddFollowers: Add Selected Tokens As Followers
+YZEC.CombatTracker.Ambushed: Ambushed
 YZEC.CombatTracker.ChooseCombatant: Choose a Combatant
 YZEC.CombatTracker.DuplicateCombatant: Duplicate Combatant
 YZEC.CombatTracker.FastAction: Fast Action

--- a/src/lang/sv.yml
+++ b/src/lang/sv.yml
@@ -35,6 +35,10 @@ SETTINGS.InitiativeSortOrderDescending: Fallande (Högst först)
 SETTINGS.InitiativeSortOrderHint: Standardsorteringsordning för initiativ.
 SETTINGS.MaxDrawSize: Maximalt antal kort som kan dras
 SETTINGS.MaxDrawSizeHint: Maximalt antal kort som kan dras samtidigt av en enskild stridsdeltagare.
+SETTINGS.ShowAmbushed: Visa "Utsatt för bakhåll"-knappen
+SETTINGS.ShowAmbushedHint: >-
+  Om ytterligare knapp ska visas i stridsöversikten för att ange att en karaktär är utsatt för bakhåll.
+  Karaktärer utsatta för bakhåll lägger till initiativkortlekens storlek till sitt initiativvärde och hamnar sist i turordningen.
 SETTINGS.SlowAndFastActions: Aktivera långsamma & snabba handlingar
 SETTINGS.SlowAndFastActionsHint: >-
   Om ytterligare knappar för långsamma & snabba handlingar ska visas i stridsöversikten.
@@ -42,6 +46,7 @@ YZEC.Combat.Initiative.ChooseCard: Välj ett kort
 YZEC.Combat.Initiative.Draw: '{name}s initiativ'
 YZEC.Combat.Initiative.ResetDeck: Blanda in alla kastade initiativkort i leken
 YZEC.CombatTracker.AddFollowers: Lägg till valda spelfigurer Som följeslagare
+YZEC.CombatTracker.Ambushed: Utsatt för bakhåll
 YZEC.CombatTracker.ChooseCombatant: Välj en stridsdeltagare
 YZEC.CombatTracker.DuplicateCombatant: Duplicera stridsdeltagare
 YZEC.CombatTracker.FastAction: Snabb handling

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -137,6 +137,20 @@ YZEC.CombatTracker = {
         },
       },
     ],
+    ambushed: [
+      {
+        eventName: 'ambushed-button-clicked',
+        label: 'YZEC.CombatTracker.Ambushed',
+        icon: 'fas fa-face-surprise',
+        id: 'ambushed-button',
+        property: 'ambushed',
+        visibility: 'owner',
+        condition: (_combat, combatant) => {
+          const notInGroup = !combatant.groupId;
+          return notInGroup;
+        },
+      },
+    ],
   },
 };
 

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -50,6 +50,7 @@ export const SETTINGS_KEYS = {
   /** @type {'singleAction'} */ SINGLE_ACTION: 'singleAction',
   /** @type {'resetEachRound'} */ RESET_EACH_ROUND: 'resetEachRound',
   /** @type {'autoSelectBestCard'} */ AUTO_SELECT_BEST_CARD: 'autoSelectBestCard',
+  /** @type {'showAmbushed'} */ SHOW_AMBUSHED: 'showAmbushed',
 };
 
 /** @enum {string} */

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -112,6 +112,16 @@ export function registerSystemSettings() {
     requiresReload: true,
   });
 
+  game.settings.register(MODULE_ID, SETTINGS_KEYS.SHOW_AMBUSHED, {
+    name: 'SETTINGS.ShowAmbushed',
+    hint: 'SETTINGS.ShowAmbushedHint',
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: true,
+    requiresReload: true,
+  });
+
   game.settings.register(MODULE_ID, SETTINGS_KEYS.DUPLICATE_COMBATANTS_ON_START, {
     name: 'SETTINGS.DuplicateCombatantsOnCombatStart',
     hint: 'SETTINGS.DuplicateCombatantsOnCombatStartHint',

--- a/src/sidebar/combat-tracker.js
+++ b/src/sidebar/combat-tracker.js
@@ -35,6 +35,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
       action8: YearZeroCombatTracker.#onCombatantControl,
       action9: YearZeroCombatTracker.#onCombatantControl,
       lockInitiative: YearZeroCombatTracker.#onCombatantControl,
+      ambushed: YearZeroCombatTracker.#onCombatantControl,
     } };
 
   /** @override */
@@ -527,6 +528,10 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
 
         if (game.settings.get(MODULE_ID, SETTINGS_KEYS.RESET_EACH_ROUND)) {
           cfg.buttons.unshift(...YZEC.CombatTracker.DefaultCombatantControls.lockInitiative);
+        }
+
+        if (game.settings.get(MODULE_ID, SETTINGS_KEYS.SHOW_AMBUSHED)) {
+          cfg.buttons.unshift(...YZEC.CombatTracker.DefaultCombatantControls.ambushed);
         }
 
         CONFIG.YZE_COMBAT.CombatTracker.config = cfg;

--- a/src/templates/combat/choose-combatant-dialog.hbs
+++ b/src/templates/combat/choose-combatant-dialog.hbs
@@ -3,7 +3,7 @@
     <label>{{localize "YZEC.CombatTracker.ChooseCombatant"}}</label>
     <select id="initiative-swap">
       {{#each combatants}}
-        <option value="{{id}}">{{flags.yze-combat.cardName}}. {{name}}</option>
+        <option value="{{id}}">{{flags.yze-combat.cardValue}}. {{name}}</option>
       {{/each}}
     </select>
   </div>


### PR DESCRIPTION
## Summary
Added support for Ambushed according to [YZE SRD page 17](https://freeleaguepublishing.com/wp-content/uploads/2023/11/YZE-Standard-Reference-Document.pdf). Instead of drawing from the highest numbered cards (as the SRD says), the ambushed combatant adds "initiative deck size" to their initiative value to ensure that their turn is after after all non-ambushed combatants. Provided localization in EN and SV, but not in FR.

## Checklist

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
