### PR TITLE
fix: 🐛 Client Hooks control module configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,16 @@ Go to the module's settings, and add the ID or name of the initiative deck you w
 Listen for the following Hook to add your own YZE Combat's configuration:
 
 ```js
-Hooks.once('yzeCombatInit', async yzec => {
-  // Sets the initiative deck's ID or name in the game settings.
+// Calling the `yzeCombatReady` will check if the current user is a GM or not.
+// Calling the `yzeCombatInit` will bypass this validation.
+// These configurations will only be executed Once. This means that after you
+//   call the `register` method, calling it again will not update the settings.
+// If you want to reconfigure, use the parameter `once` set to `false`.
+// The methods `setInitiativeDeck` and `setDiscardPile` do not mark the module
+//   as configured per default. If you are not calling the `register` method,
+//   set the `finishConfiguration` to `true` to mark the module as configured.
+Hooks.once('yzeCombatReady', async (yzec) => {
+  // Sets the initiative deck's ID in the game settings.
   // If you don't, a new default one will be created and linked in the settings.
   await yzec.setInitiativeDeck('azerty0123456789');
 

--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -17,6 +17,8 @@ SETTINGS.AutoSelectBestCard: Choose Best Card
 SETTINGS.AutoSelectBestCardHint: >-
   Forgo the card selection dialog on multiple drawn initiative cards, instead opting for
   the best (fastest) initiative card.
+SETTINGS.Configured: Module Configured
+SETTINGS.ConfiguredHint: Whether the module has been configured via API.
 SETTINGS.DiscardPile: Discard Pile ID
 SETTINGS.DiscardPileHint: ID or name of the Discard pile where to put the drawn initiative cards.
 SETTINGS.DuplicateCombatantsOnCombatStart: Duplicate Combatants

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -51,6 +51,7 @@ export const SETTINGS_KEYS = {
   /** @type {'resetEachRound'} */ RESET_EACH_ROUND: 'resetEachRound',
   /** @type {'autoSelectBestCard'} */ AUTO_SELECT_BEST_CARD: 'autoSelectBestCard',
   /** @type {'showAmbushed'} */ SHOW_AMBUSHED: 'showAmbushed',
+  /** @type {'configured'} */ CONFIGURED: 'configured',
 };
 
 /** @enum {string} */

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -162,6 +162,15 @@ export function registerSystemSettings() {
     },
     default: CONFIG.YZE_COMBAT.ultimateMaxDrawSize,
   });
+
+  game.settings.register(MODULE_ID, SETTINGS_KEYS.CONFIGURED, {
+    name: 'SETTINGS.Configured',
+    hint: 'SETTINGS.ConfiguredHint',
+    scope: 'world',
+    config: false,
+    type: Boolean,
+    default: false,
+  });
 }
 
 /** @param {number} _v value */

--- a/src/utils/client-hooks.js
+++ b/src/utils/client-hooks.js
@@ -1,4 +1,4 @@
-import { CARD_STACK, MODULE_ID } from '@module/constants';
+import { CARD_STACK, MODULE_ID, SETTINGS_KEYS } from '@module/constants';
 
 /**
  * An abstract class (cannot be instantiated) with utility methods
@@ -14,40 +14,56 @@ export default class YearZeroCombatHook {
    * Registers game settings for this module.
    * @param {Object.<string, boolean|string|number>} settings
    *   Pairs of key-value to register in the game settings
-   * @param {boolean} [once=true] Whether to register the setting only if the setting is undefined
+   * @param {boolean} [once=true] Only register the settings if the registration never happened
+   * @param {boolean} [finishConfiguration=true] Whether to set the module as configured after registration
    * @returns {Promise.<void>}
    */
-  static async register(settings, once = true) {
-    if (!game.user.isGM) return;
+  static async register(settings, once = true, finishConfiguration = true) {
+    if (!game.user?.isGM) return;
+
+    const isConfigured = await game.settings.get(MODULE_ID, SETTINGS_KEYS.CONFIGURED);
+    if (isConfigured && once) return;
+
     for (const [k, v] of Object.entries(settings)) {
       try {
-        if (once && game.settings.get(MODULE_ID, k)) continue;
         await game.settings.set(MODULE_ID, k, v);
       }
       catch (err) {
         console.error(err);
       }
     }
+
+    if (finishConfiguration) { await this.finishConfiguration(); }
+  }
+
+  static async finishConfiguration() {
+    if (!game.user?.isGM) return;
+
+    await game.settings.set(MODULE_ID, SETTINGS_KEYS.CONFIGURED, true);
   }
 
   /**
    * Sets the initiative deck's ID (or name) in the game settings.
+   * Should be called before the `register` method, or called with the `once` parameter set to `false`.
    * @param {string}   id         ID or name of the card stack to register
    * @param {boolean} [once=true] Whether to register the setting only if the setting is undefined
+   * @param {boolean} [finishConfiguration=false] Whether to set the module as configured after registration
    * @returns {Promise.<void>}
    */
-  static async setInitiativeDeck(id, once = true) {
-    return this.register({ [CARD_STACK.INITIATIVE_DECK]: id }, once);
+  static async setInitiativeDeck(id, once = true, finishConfiguration = false) {
+    return this.register({ [CARD_STACK.INITIATIVE_DECK]: id }, once, finishConfiguration);
   }
 
   /**
    * Sets the discard pile's ID (or name) in the game settings.
+   * Should be called before the `register` method, or called with the `once` parameter set to `false`.
    * @param {string}   id         ID or name of the card stack to register
    * @param {boolean} [once=true] Whether to register the setting only if the setting is undefined
+   * @param {boolean} [finishConfiguration=false] Whether to set the module as configured after registration
    * @returns {Promise.<void>}
    */
-  static async setDiscardPile(id, once = true) {
-    return this.register({ [CARD_STACK.DISCARD_PILE]: id }, once);
+  static async setDiscardPile(id, once = true, finishConfiguration = false) {
+    return this.register({ [CARD_STACK.DISCARD_PILE]: id }, once, finishConfiguration);
   }
 
   /**

--- a/static/module.json
+++ b/static/module.json
@@ -2,7 +2,7 @@
   "id": "yze-combat",
   "title": "Year Zero Engine: ⚔️ Combat",
   "description": "Adds YZE combat mechanics to a game system: Card initiative, slow & fast actions, groups, and more!",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "compatibility": {
     "minimum": 13.341,
     "verified": 13.345,

--- a/static/module.json
+++ b/static/module.json
@@ -25,6 +25,11 @@
     {
       "name": "FloRad",
       "url": "https://gitlab.com/florad92"
+    },
+    {
+      "name": "CussaMitre",
+      "url": "https://hodpub.com",
+      "discord": "CussaMitre"
     }
   ],
   "bugs": "https://github.com/fvtt-fria-ligan/yearzero-combat-fvtt/issues",


### PR DESCRIPTION
## Summary
- Add new setting: `configured`
- When calling the `register`, check if the module is already `configured`.
- If `once` is `true` and `configured` is true, return
- Add new parameter `finishConfiguration`
- `setInitiaveDeck` and `setDiscardPile` do not mark the module as `configured`
- Improve documentation

Fixes #66 

## Checklist

### PR Type
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
