### PR TITLE
Fix/group management

### DIFF
--- a/src/sidebar/combat-tracker.js
+++ b/src/sidebar/combat-tracker.js
@@ -220,7 +220,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
       condition: li => {
         const combatant = getCombatant(li);
         const selectedTokens = canvas?.tokens?.controlled || [];
-        const followerTokens = selectedTokens?.filter(t => t.actor.id != combatant.actorId);
+        const followerTokens = selectedTokens?.filter(t => t.id != combatant.tokenId);
         return canvas?.ready &&
           followerTokens.length > 0 &&
           followerTokens.every(t => t.actor?.isOwner);
@@ -228,7 +228,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
       callback: async li => {
         const combatant = getCombatant(li);
         const selectedTokens = canvas?.tokens?.controlled;
-        const followerTokens = selectedTokens?.filter(t => t.actor.id != combatant.actorId);
+        const followerTokens = selectedTokens?.filter(t => t.id != combatant.tokenId);
 
         if (followerTokens) {
           await combatant.promoteLeader();

--- a/src/sidebar/combat-tracker.js
+++ b/src/sidebar/combat-tracker.js
@@ -193,7 +193,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
 
     // 🚫 Remove Group Leader
     groupMenu.push({
-      name: 'YZEC.CombatTracker.removeFromGroup',
+      name: 'YZEC.CombatTracker.RemoveGroupLeader',
       icon: YZEC.Icons.removeLeader,
       condition: li => {
         const c = getCombatant(li);

--- a/src/sidebar/combat-tracker.js
+++ b/src/sidebar/combat-tracker.js
@@ -186,7 +186,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
       icon: YZEC.Icons.makeLeader,
       condition: li => {
         const c = getCombatant(li);
-        return !c.isGroupLeader && c.actor?.isOwner;
+        return game.user.isGM && !c.isGroupLeader && c.actor?.isOwner;
       },
       callback: async li => getCombatant(li).promoteLeader(),
     });
@@ -197,7 +197,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
       icon: YZEC.Icons.removeLeader,
       condition: li => {
         const c = getCombatant(li);
-        return c.isGroupLeader && c.actor?.isOwner;
+        return game.user.isGM && c.isGroupLeader && c.actor?.isOwner;
       },
       callback: async li => getCombatant(li).unpromoteLeader(),
     });
@@ -208,7 +208,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
       icon: YZEC.Icons.color,
       condition: li => {
         const c = getCombatant(li);
-        return c.isGroupLeader && c.actor?.isOwner;
+        return game.user.isGM && c.isGroupLeader && c.actor?.isOwner;
       },
       callback: li => new YearZeroCombatGroupColor(getCombatant(li)).render(true),
     });
@@ -221,7 +221,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
         const combatant = getCombatant(li);
         const selectedTokens = canvas?.tokens?.controlled || [];
         const followerTokens = selectedTokens?.filter(t => t.id != combatant.tokenId);
-        return canvas?.ready &&
+        return game.user.isGM && canvas?.ready &&
           followerTokens.length > 0 &&
           followerTokens.every(t => t.actor?.isOwner);
       },
@@ -274,7 +274,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
       icon: YZEC.Icons.unfollow,
       condition: li => {
         const c = getCombatant(li);
-        return c.groupId && !c.isGroupLeader && c.actor?.isOwner;
+        return game.user.isGM && c.groupId && !c.isGroupLeader && c.actor?.isOwner;
       },
       callback: async li => {
         const combatant = getCombatant(li);


### PR DESCRIPTION
## Summary
Fixes for group management, including for issues #68 and #73

Minor behavior change: Deafeated group members are no longer removed from the group. When they were, and if you remove the 'dead' status afterwards, they would get the same initiative as the group (bad if you keep them as individuals) or you would have to put them back into the group if that's what you want (unnecessary step). 

Group management doesn't make sense for players, so I made it GM only. It looked a bit random from a player perspective that a couple of these menu options showed up.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.

