### PR TITLE
fix: 🐛 Players can't choose Draw Another Card #74

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -11,6 +11,8 @@ SETTINGS.ActorSpeedAttribute: Actor's Speed Attribute
 SETTINGS.ActorSpeedAttributeHint: >-
   The property key in the actor's data to the attribute that defines how many
   initiative cards are kept (speed) by the combatant (e.g. system.speed.value).
+SETTINGS.AllowReroll: Reroll Initiative
+SETTINGS.AllowRerollHint: Whether to allow players to draw another initiative card.
 SETTINGS.AutoDraw: Automatic Initiative Draw
 SETTINGS.AutoDrawHint: Whether to automatically draw initiative cards when combat starts.
 SETTINGS.AutoSelectBestCard: Choose Best Card

--- a/src/lang/sv.yml
+++ b/src/lang/sv.yml
@@ -9,6 +9,8 @@ SETTINGS.ActorDrawSizeAttributeHint: >-
 SETTINGS.ActorSpeedAttribute: Karaktärens attribut för hastighet
 SETTINGS.ActorSpeedAttributeHint: >-
   Egenskapsnyckeln i karaktärens data som definierar hur många initiativkort som behålls (hastighet) av stridsdeltagaren (t.ex. system.speed.value).
+ETTINGS.AllowReroll: Dra annat initiativ
+SETTINGS.AllowRerollHint: Om spelare ska kunna dra ett annat initiativkort.
 SETTINGS.AutoDraw: Automatisk initiativdragning
 SETTINGS.AutoDrawHint: Om initiativkort ska dras automatiskt när striden börjar.
 SETTINGS.AutoSelectBestCard: Välj bästa kortet

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -52,6 +52,7 @@ export const SETTINGS_KEYS = {
   /** @type {'autoSelectBestCard'} */ AUTO_SELECT_BEST_CARD: 'autoSelectBestCard',
   /** @type {'showAmbushed'} */ SHOW_AMBUSHED: 'showAmbushed',
   /** @type {'configured'} */ CONFIGURED: 'configured',
+  /** @type {'allowReroll'} */ ALLOW_REROLL: 'allowReroll',
 };
 
 /** @enum {string} */

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -171,6 +171,15 @@ export function registerSystemSettings() {
     type: Boolean,
     default: false,
   });
+
+  game.settings.register(MODULE_ID, SETTINGS_KEYS.ALLOW_REROLL, {
+    name: 'SETTINGS.AllowReroll',
+    hint: 'SETTINGS.AllowRerollHint',
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+  });
 }
 
 /** @param {number} _v value */

--- a/src/sidebar/combat-tracker.js
+++ b/src/sidebar/combat-tracker.js
@@ -124,7 +124,13 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
 
     // Changes existing buttons.
     const rerollIndex = contextMenu.findIndex(m => m.name === 'COMBAT.CombatantReroll');
-    if (~rerollIndex) contextMenu[rerollIndex].icon = YZEC.Icons.cards;
+    if (~rerollIndex) {
+      contextMenu[rerollIndex].icon = YZEC.Icons.cards;
+      contextMenu[rerollIndex].condition = li => {
+        return (game.user.isGM ||
+          getCombatant(li).isOwner && game.settings.get(MODULE_ID, SETTINGS_KEYS.ALLOW_REROLL));
+      };
+    }
 
     // Adds "Swap Initiative" context menu entry before 'COMBAT.CombatantReroll'.
     contextMenu.splice(rerollIndex, 0, {


### PR DESCRIPTION
## Summary
This change adds a setting that when enabled allows players to "Draw Another Card" in the combatant context menu. Resolves #74.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
