### PR TITLE
fix: 🐛 Reset Initiative doesn't trigger reset cards

### DIFF
--- a/src/combat/combat.js
+++ b/src/combat/combat.js
@@ -269,6 +269,12 @@ export default class YearZeroCombat extends Combat {
     if (soft) await this.update({ combatants: this.combatants.toObject() }, { diff: false });
     else await this.update({ turn: 0, combatants: this.combatants.toObject() }, { diff: false });
 
+    // Reset deck here, so that other modules calling resetAll() get the correct deck state.
+    if (!soft) {
+      const lockedCards = this.combatants.filter(c => c.lockInitiative).map(c => c.cardValue);
+      await Utils.resetInitiativeDeck(true, lockedCards);
+    }
+
     return this;
   }
 

--- a/src/combat/combatant.js
+++ b/src/combat/combatant.js
@@ -224,6 +224,7 @@ export default class YearZeroCombatant extends Combatant {
       [`flags.${MODULE_ID}`]: {
         cardValue: null,
         cardName: '',
+        lockInitiative: false,
       },
     });
   }

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -133,7 +133,8 @@ YZEC.CombatTracker = {
         condition: (combat, combatant) => {
           const combatHasBegun = combat.active && combat.started;
           const notInGroup = !combatant.groupId;
-          return combatHasBegun && notInGroup;
+          const hasCard = combatant.cardValue !== null;
+          return combatHasBegun && notInGroup && hasCard;
         },
       },
     ],


### PR DESCRIPTION
## Summary
Fix for #70. Resetting the deck when resetting initiative.
Also found an issue with YearZeroCombatant.lockInitiative not being set to false when doing resetInitiative. If lockInitiative is true, the combatant will not draw cards. resetInitiative clears the card so it must also set lockInitiative to false otherwise there will be an error. Testable with: lock, reset initiative, draw. (lock requires Reset Initiative Each Round to be checked)

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
