### PR TITLE
fix: 🐛 Initiative cards not suffled in case of drawsize >1 #49

### DIFF
--- a/src/combat/cards.js
+++ b/src/combat/cards.js
@@ -37,7 +37,12 @@ export default class YearZeroCards extends Cards {
     for (const card of drawn) {
       const createData = card.toObject();
       if (card.isHome || !createData.origin) createData.origin = this.id;
-      toCreate.push(createData);
+      // Card may already exist in discard pile if the initiative deck was reshuffled while
+      // a card selection dialog was open and the player selected the same card as someone else.
+      // In this case, allow the player to "draw" the duplicate, but don't create a duplicate in the discard pile.
+      if (!to.cards.contents.find(c => c.id === card.id)) {
+        toCreate.push(createData);
+      }
       if (card.isHome) toUpdate.push({ _id: card.id, drawn: true });
       else toDelete.push(card.id);
     }

--- a/src/combat/cards.js
+++ b/src/combat/cards.js
@@ -15,11 +15,12 @@ export default class YearZeroCards extends Cards {
    * Draws cards for initiative.
    * @param {Cards}   to          The cards document to which the cards are deposited
    * @param {number} [qty=1]      How many cards to draw
-   * @param {number} [drawMode=0] How to draw the cards, e.g. from the top of the deck
+   * @param {number} [drawMode=2] How to draw the cards, e.g. from the top of the deck
+   * @param {Card[]} [cards]      The cards to draw (if they have been peeked at for example)
    * @returns {Promise.<Card[]>} An array of drawn cards, in the order they were drawn
    * @see {@link CONST.CARD_DRAW_MODES}
    */
-  async drawInitiative(to, qty = 1, drawMode = foundry.CONST.CARD_DRAW_MODES.TOP) {
+  async drawInitiative(to, qty = 1, drawMode = foundry.CONST.CARD_DRAW_MODES.RANDOM, cards = null) {
     // Exits early if invalid deck type.
     if (this.type !== 'deck') {
       const msg = game.i18n.localize('YZEC.WARNING.InvalidDeckType');
@@ -27,7 +28,7 @@ export default class YearZeroCards extends Cards {
     }
 
     // Draws the cards.
-    const drawn = this._drawCards(qty, drawMode);
+    const drawn = cards ?? this._drawCards(qty, drawMode);
 
     // Processes the card data.
     const toCreate = [];
@@ -47,6 +48,58 @@ export default class YearZeroCards extends Cards {
       this.deleteEmbeddedDocuments('Card', toDelete),
     ]);
 
+    // Returns the drawn cards.
+    return this.updateEmbeddedDocuments('Card', toUpdate);
+  }
+
+  /**
+   * Peek at cards for initiative. Sets them as drawn but does not remove them from the deck.
+   * @param {number} [qty=1]      How many cards to draw
+   * @param {number} [drawMode=2] How to draw the cards, e.g. from the top of the deck
+   * @returns {Card[]} An array of cards, in the order they were drawn
+   * @see {@link CONST.CARD_DRAW_MODES}
+   */
+  async peekInitiative(qty = 1, drawMode = foundry.CONST.CARD_DRAW_MODES.RANDOM) {
+    // Exits early if invalid deck type.
+    if (this.type !== 'deck') {
+      const msg = game.i18n.localize('YZEC.WARNING.InvalidDeckType');
+      throw new TypeError(msg);
+    }
+
+    // Draws the cards.
+    const drawn = this._drawCards(qty, drawMode);
+
+    // Processes the card data.
+    const toUpdate = [];
+    for (const card of drawn) {
+      if (card.isHome) {
+        // Set to drawn so that other players can't draw it.
+        toUpdate.push({ _id: card.id, drawn: true });
+      }
+    }
+    // Returns the drawn cards.
+    return this.updateEmbeddedDocuments('Card', toUpdate);
+  }
+
+  /**
+   * Returns peeked at cards. Sets them as not drawn.
+   * @param {Card[]} [cards]      The cards to return
+   * @returns {Card[]}            An array of cards, in the order they were drawn
+   */
+  async returnPeekedAtCards(cards) {
+    // Exits early if invalid deck type.
+    if (this.type !== 'deck') {
+      const msg = game.i18n.localize('YZEC.WARNING.InvalidDeckType');
+      throw new TypeError(msg);
+    }
+
+    // Processes the card data.
+    const toUpdate = [];
+    for (const card of cards) {
+      if (card.isHome) {
+        toUpdate.push({ _id: card.id, drawn: false });
+      }
+    }
     // Returns the drawn cards.
     return this.updateEmbeddedDocuments('Card', toUpdate);
   }


### PR DESCRIPTION
## Summary
Issue #49 described that when several players have drawSize > 1, the initiative deck can easily run out of cards because the unselected cards end up in the discard pile instead of being put back in the initative deck.

Complications:
- When drawing multiple cards, all of them end up in the discard pile
- The player is not allowed to remove cards from the discard pile
- The player is not allowed shuffle the initiative deck, which should be done after having looked at the top cards.

The solution was to
1. peek at cards
2. choose card
3. return or draw cards

And the draw mode was changed to random instead of shuffling the initiative deck.

Also added a guard against trying to create duplicate entries in the discard pile, which could happen if the initiative deck is reset with multiple card dialogs open. In this case, allow the duplicate initiative value, but don't try to create a duplicate in the discard pile (this generates an error and forces user to Reset Initiative).

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
