### PR TITLE
fix: 🐛 Resource doesn't update immediately for combatant duplicates #54

### DIFF
--- a/src/combat/combatant.js
+++ b/src/combat/combatant.js
@@ -1,6 +1,7 @@
 import { YZEC } from '@module/config';
 import { CARDS_DRAW_KEEP_STATES, MODULE_ID, SETTINGS_KEYS } from '@module/constants';
 import { getCanvas, getCombatantSortOrderModifier } from '@utils/utils';
+import { getCombatantsSharingToken } from './duplicate-combatant.js';
 
 export default class YearZeroCombatant extends Combatant {
 
@@ -336,5 +337,26 @@ export default class YearZeroCombatant extends Combatant {
         },
       },
     });
+  }
+
+  /**
+   * Update the value of the tracked resource for this Combatant.
+   * @returns {null|object}
+   * @override
+   */
+  updateResource() {
+    super.updateResource();
+
+    // updateResource() is only called on token.combatant, so if there are duplicate combatants
+    // sharing the same token, we need to update their resource values as well.
+
+    // Grab the superclass prototype (relative to this instance’s class)
+    const superProto = Object.getPrototypeOf(Object.getPrototypeOf(this));
+    const superUpdateResource = superProto.updateResource;
+
+    for (const c of getCombatantsSharingToken(this)) {
+      if (c.id === this.id) continue;
+      superUpdateResource.call(c);
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fix for #54.
Token just updates a single combatant. Override updateResource() on combatant and update all combatants sharing the token.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
