### PR TITLE
fix: 🐛 Combat tracker becomes unusable #79

### DIFF
--- a/src/sidebar/combat-tracker.js
+++ b/src/sidebar/combat-tracker.js
@@ -556,6 +556,7 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
    */
   static #setTurnProperties(combatant, turn) {
     const flags = combatant.flags[MODULE_ID];
+    if (!flags) return {};
     // FIXME: Figure out why these turn up as flags.
     delete flags.fastAction;
     delete flags.slowAction;


### PR DESCRIPTION
## Summary
Resolves #79
Combatant flags don't exist when the module is initialized. Added a guard to prevent combat tracker from crashing. The sort order between combatants added before and after the module was enabled may be incorrect until the next turn. Other than that it seems ok.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
