### PR TITLE
fix: 🐛 error when player triggers next round

### DIFF
--- a/src/sidebar/combat-tracker.js
+++ b/src/sidebar/combat-tracker.js
@@ -55,12 +55,19 @@ export default class YearZeroCombatTracker extends foundry.applications.sidebar.
 
   /** @override */
   async _preparePartContext(partId, context, options) {
-    const data = await super._preparePartContext(partId, context, options);
-    return {
-      ...data,
-      config: YZEC,
-    };
-
+    const data = { ...await super._preparePartContext(partId, context, options), config: YZEC };
+    if (partId === 'footer' && data.control && !game.user.isGM) {
+      // Disable turn controls for non-GM users if they are last in the turn tracker.
+      // If the player causes the round to advance there will be an error when trying to update flags (history).
+      // I think there is a way to set permissisons on the combat document to allow players to advance rounds,
+      // similar to how Combat allows players to modify rounds and turns, but it involves creating proper metadata
+      // for YearZeroCombat. This is a simpler solution for now just to avoid errors.
+      const combat = this.viewed;
+      if (combat?.turn === combat?.turns?.length - 1) {
+        data.control = false;
+      }
+    }
+    return data;
   }
 
   /** @override */


### PR DESCRIPTION
## Summary
Avoid error due to player not having the rights to modify flags on the combat document. This happens when the last player in the turn tracker clicks next turn or end turn. The fix avoids this by disabling those buttons for combatants last in the turn tracker unless they are GMs.
There probably is a better fix, which is outlined in the code comments.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
