### PR TITLE
fix: 🐛 followers show initiative button

### DIFF
--- a/src/combat/combatant.js
+++ b/src/combat/combatant.js
@@ -83,9 +83,9 @@ export default class YearZeroCombatant extends Combatant {
     return this.unsetFlag(MODULE_ID, 'isGroupLeader');
   }
 
-  // get isFollower() {
-  //   return !this.isGroupLeader && !!this.groupId;
-  // }
+  get isFollower() {
+    return !this.isGroupLeader && !!this.groupId;
+  }
 
   get groupColor() {
     return this.getFlag(MODULE_ID, 'groupColor');

--- a/src/templates/sidebar/tracker.hbs
+++ b/src/templates/sidebar/tracker.hbs
@@ -21,9 +21,13 @@
                 {{/if}}
             {{!-- Roll Initiative --}}
             {{else if isOwner}}
+                {{#unless this.combatant.isFollower}}
                 <button type="button" class="combatant-control roll initiative" data-action="rollInitiative" data-tooltip
                         aria-label="{{ localize "COMBAT.InitiativeRoll" }}"
                         style="--initiative-icon: url('{{ @root.initiativeIcon.icon }}'); --initiative-icon-hover: url('{{ @root.initiativeIcon.hover }}');"></button>
+                {{else}}
+                    <span class="initiative"></span>
+                {{/unless}}
             {{else}}
             <span class="initiative"></span>
             {{/if}}


### PR DESCRIPTION
## Summary
Fixes the following issue: The "roll initiative" button is visible for followers. This is not only misleading (they use the group leader's initiative) but it also makes it difficult to see that a combatant has been added as a follower.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
